### PR TITLE
Adding support for classic SSL policy conversion, handling bulind named expression

### DIFF
--- a/nspepi/check_invalid_config
+++ b/nspepi/check_invalid_config
@@ -77,7 +77,7 @@ if (!(-z $invalid_config_file)) {
 	print "\nThe following configuration lines will get errors in ".$buildVersion." and both they and dependent configuration will be removed from the configuration:\n";
 	system("cat $invalid_config_file");
 	print "\nThe nspepi upgrade tool can be useful in converting your configuration - see the documentation at https://docs.citrix.com/en-us/citrix-adc/current-release/appexpert/policies-and-expressions/introduction-to-policies-and-exp/converting-policy-expressions-nspepi-tool.html.\n";
-	print "\nNOTE: the nspepi tool doesn't convert the following configurations:\n\t1. SureConnect commands\n\t2. PriorityQueuing commands\n\t3. HTTP Denial of Service Protection commands\n\t4. Classic SSL commands\n\t5. HTMLInjection commands.\n";
+	print "\nNOTE: the nspepi tool doesn't convert the following configurations:\n\t1. SureConnect commands\n\t2. PriorityQueuing commands\n\t3. HTTP Denial of Service Protection commands\n\t4. HTMLInjection commands.\n";
     if (!(-z $deprecated_config_file)) {
         print "\nNOTE: some deprecated commands have also been detected in the config file, please check ".$deprecated_config_file." file for the deprecated commands.\n";
     } else {

--- a/nspepi/nspepi2/convert_auth_cmd.py
+++ b/nspepi/nspepi2/convert_auth_cmd.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2021-2022 Citrix Systems, Inc.  All rights reserved.
+# Copyright 2021-2023 Citrix Systems, Inc.  All rights reserved.
 # Use of this software is governed by the license terms, if any,
 # which accompany or are included with this software.
 
@@ -472,3 +472,16 @@ class Authentication(cli_cmds.ConvertConfig):
                 else:
                     tree_list.append(tree)
         return tree_list
+
+    @common.register_for_cmd("add", "authentication", "vserver")
+    def convert_add_auth_vserver(self, add_vserver_parse_tree):
+        """
+        Handles add authentication vserver
+        """
+        if cli_cmds.no_conversion_collect_data:
+            return []
+        protocol_type = add_vserver_parse_tree.positional_value(1).value
+        vs_name = add_vserver_parse_tree.positional_value(0).value.lower()
+        if protocol_type.upper() == "SSL":
+            cli_cmds.authentication_ssl_vserver.append(vs_name)
+        return [add_vserver_parse_tree]

--- a/nspepi/nspepi2/convert_patclass_commands.py
+++ b/nspepi/nspepi2/convert_patclass_commands.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2021 Citrix Systems, Inc.  All rights reserved.
+# Copyright 2021-2023 Citrix Systems, Inc.  All rights reserved.
 # Use of this software is governed by the license terms, if any,
 # which accompany or are included with this software.
 
@@ -25,6 +25,8 @@ class PATCLASS(cli_cmds.ConvertConfig):
         Returns:
             tree: Processed command parse tree for add policy patclass command
         """
+        if cli_cmds.no_conversion_collect_data:
+            return []
         patset_tree = CLICommand('add', 'policy', 'patset')
         name = CLIPositionalParameter(tree.positional_value(0).value)
         patset_tree.add_positional(name)
@@ -41,6 +43,8 @@ class PATCLASS(cli_cmds.ConvertConfig):
         Returns:
             tree: Processed command parse tree for bind policy patclass command
         """
+        if cli_cmds.no_conversion_collect_data:
+            return []
         patset_tree = CLICommand('bind', 'policy', 'patset')
         name = CLIPositionalParameter(tree.positional_value(0).value)
         pattern = CLIPositionalParameter(tree.positional_value(1).value)

--- a/nspepi/nspepi2/convert_responder_command.py
+++ b/nspepi/nspepi2/convert_responder_command.py
@@ -31,6 +31,10 @@ class Responder(cli_cmds.ConvertConfig):
         """
         add responder action <name> <type> <target>
         """
+        if cli_cmds.no_conversion_collect_data:
+            tree = Responder.convert_adv_expr_list(
+                	tree, [2, "reasonPhrase", "headers"])
+            return []
         action_name = tree.positional_value(0).value.lower()
         action_type = tree.positional_value(1).value.lower()
         # If action is noop, then don't return action 
@@ -52,6 +56,9 @@ class Responder(cli_cmds.ConvertConfig):
         Saved policy name in policy_list.
         add responder policy <name> <rule> <action>
         """
+        if cli_cmds.no_conversion_collect_data:
+            tree = Responder.convert_adv_expr_list(tree, [1])
+            return []
         policy_name = tree.positional_value(0).value
         policy_action = tree.positional_value(2).value.lower()
         if (policy_action in self._noop_action_list):
@@ -77,6 +84,8 @@ class Responder(cli_cmds.ConvertConfig):
               HTTP/SSL vservers
         tree - bind command parse tree
         """
+        if cli_cmds.no_conversion_collect_data:
+            return []
         # If no filter policy is configured, then no need to process
         # responder bindings
         if not cli_cmds.filter_policy_exists:
@@ -91,10 +100,8 @@ class Responder(cli_cmds.ConvertConfig):
         position = "inplace"
         bind_type_to_check = ["REQ_OVERRIDE", "REQ_DEFAULT"]
         if get_bind_type in bind_type_to_check:
-            if (policy_name.lower() not in self._terminating_policy_list):
-                 # Set below flags only if added vserver is of HTTP/SSL protocol
-                 if get_goto_arg.upper() in ("END", "USE_INVOCATION_RESULT"):
-                     Responder.resp_global_goto_exists = True
+            if get_goto_arg.upper() in ("END", "USE_INVOCATION_RESULT"):
+                Responder.resp_global_goto_exists = True
             self.convert_global_bind(
                 tree, tree, policy_name, module, priority_arg, goto_arg, position)
             return []
@@ -112,6 +119,8 @@ class Responder(cli_cmds.ConvertConfig):
         When responder policy is bound:
         1. Check if GOTO is END/USE_INVOCATION_RESULT for HTTP/SSL vservers
         """
+        if cli_cmds.no_conversion_collect_data:
+            return []
         # If no filter policy is configured, then no need to process
         # responder bindings
         if not cli_cmds.filter_policy_exists:
@@ -126,9 +135,8 @@ class Responder(cli_cmds.ConvertConfig):
         goto_arg = "gotoPriorityExpression"
         if cli_cmds.vserver_protocol_dict[vs_name] in ("HTTP", "SSL"):
             # Set below flags only if vserver is of ptotocol HTTP/SSL
-            if ((policy_name.lower() not in self._terminating_policy_list) and
-                (get_goto_arg.upper() in ("END", "USE_INVOCATION_RESULT"))):
-                 Responder.resp_vserver_goto_exists = True
+            if (get_goto_arg.upper() in ("END", "USE_INVOCATION_RESULT")):
+                Responder.resp_vserver_goto_exists = True
 
             if not bind_parse_tree.keyword_exists('type'):
                 keyword_arg = CLIKeywordParameter(CLIKeywordName('type'))

--- a/nspepi/nspepi2/convert_rewrite_command.py
+++ b/nspepi/nspepi2/convert_rewrite_command.py
@@ -48,6 +48,9 @@ class Rewrite(cli_cmds.ConvertConfig):
 
     @common.register_for_cmd("add", "rewrite", "action")
     def convert_rewrite_action(self, tree):
+        if cli_cmds.no_conversion_collect_data:
+            tree = Rewrite.convert_adv_expr_list(tree, [2, 3, "refineSearch"])
+            return []
         if tree.keyword_exists('pattern'):
             pattern_value = tree.keyword_value('pattern')[0].value
             tree.remove_keyword('pattern')
@@ -72,6 +75,9 @@ class Rewrite(cli_cmds.ConvertConfig):
         Saved policy name in policy_list.
         add rewrite policy <name> <rule> <action>
         """
+        if cli_cmds.no_conversion_collect_data:
+            tree = Rewrite.convert_adv_expr_list(tree, [1])
+            return []
         policy_name = tree.positional_value(0).value
         pol_obj = common.Policy(policy_name, self.__class__.__name__,
                                 "advanced")
@@ -89,6 +95,8 @@ class Rewrite(cli_cmds.ConvertConfig):
             HTTP/SSL vservers
         tree - bind command parse tree
         """
+        if cli_cmds.no_conversion_collect_data:
+            return []
         # If no filter policy is configured, then no need to process
         # rewrite bindings
         if not cli_cmds.filter_policy_exists:
@@ -129,6 +137,8 @@ class Rewrite(cli_cmds.ConvertConfig):
         2. vserver_protocol_dict - dict from cli_cmds and convert_lb_cmd
               packages which carries protocol as value to the key - vserver name
         """
+        if cli_cmds.no_conversion_collect_data:
+            return []
         # If no filter policy is configured, then no need to process
         # rewrite bindings
         if not cli_cmds.filter_policy_exists:
@@ -156,4 +166,3 @@ class Rewrite(cli_cmds.ConvertConfig):
                 module, priority_arg, goto_arg)
             return []
         return [bind_parse_tree]
-

--- a/nspepi/nspepi2/nspepi_helper
+++ b/nspepi/nspepi2/nspepi_helper
@@ -154,6 +154,20 @@ my %EXPR_LIST=(
     "TIME "                                 ,       'Type=11;expr=SYS.TIME',
     "URLTOKENS"                             ,       'Type=15;expr=HTTP.REQ.URL.SET_TEXT_MODE(NOURLENCODED)',
     "REQ.HTTP.URLTOKENS"                    ,       'Type=15;expr=HTTP.REQ.URL.SET_TEXT_MODE(NOURLENCODED)',
+    "FS\.COMMAND"                           ,       'Type=16;expr=invalid',
+    "FS\.DIR"                               ,       'Type=16;expr=invalid',
+    "FS\.DOMAIN"                            ,       'Type=16;expr=invalid',
+    "FS\.FILE"                              ,       'Type=16;expr=invalid',
+    "FS\.PATH"                              ,       'Type=16;expr=invalid',
+    "FS\.SERVER"                            ,       'Type=16;expr=invalid',
+    "FS\.SERVERIP"                          ,       'Type=16;expr=invalid',
+    "FS\.SERVICE"                           ,       'Type=16;expr=invalid',
+    "FS\.USER"                              ,       'Type=16;expr=invalid',
+    "CLIENT\.APPLICATION"                   ,       'Type=17;expr=invalid',
+    "CLIENT\.FILE"                          ,       'Type=17;expr=invalid',
+    "CLIENT\.OS"                            ,       'Type=17;expr=invalid',
+    "CLIENT\.REG"                           ,       'Type=17;expr=invalid',
+    "CLIENT\.SVC"                           ,       'Type=17;expr=invalid',
 );
 
 # List of classic expressions that are not convertable
@@ -305,7 +319,7 @@ sub convertExpression
     }
     # Check for client security expression expressions
     foreach (@CSEC_BLOCKED_LIST) {
-        if ($expression  =~ /\b$_/i) {
+        if ($expression  =~ /^\b$_/i) {
             print_it($LFILE,"$line\n");
             err_handle $ERR_CSEC_BLOCKED_MSG;
             return;
@@ -313,7 +327,7 @@ sub convertExpression
     }
     # Check for file system based expression expressions
     foreach (@FILE_BLOCKED_LIST) {
-        if ($expression  =~ /\b$_/i) {
+        if ($expression  =~ /^\b$_/i) {
             print_it($LFILE,"$line\n");
             err_handle $ERR_FILE_BLOCKED_MSG;
             return;
@@ -321,7 +335,7 @@ sub convertExpression
     }
     # Check for blocked expressions
     foreach (@BLOCKED_LIST) {
-        if ($expression  =~ /\b$_/i) {
+        if ($expression  =~ /^\b$_/i) {
             my $err_msg = "Conversion of $_ expression is not supported";
             print_it($LFILE,"$line\n");
             err_handle $err_msg;
@@ -830,7 +844,7 @@ sub identifyExpressions
                     parseNumericOperator($OPERATOR,$ARG);
                     return;
                 } elsif ($ARG =~ /^\S{3} (\S{3}) (\d{1,2}) (\d{2}):(\d{2}):(\d{2}) (\d{4})$/) {
-                    # Handling asctime format: Tue Nov 4 08:12:31 1994 GMT
+                    # Handling asctime format: Tue Nov 4 08:12:31 1994
                     $ARG = "GMT $6 $1 $2 $3h $4m $5s";
                     parseNumericOperator($OPERATOR,$ARG);
                     return;
@@ -909,6 +923,14 @@ sub identifyExpressions
                 err_handle $ERR_SYNTAX_MSG;
                 return;
             }
+        }
+        case 16 {
+                err_handle $ERR_FILE_BLOCKED_MSG;
+                return;
+        }
+        case 17 {
+                err_handle $ERR_CSEC_BLOCKED_MSG;
+                return;
         }
     }
 }


### PR DESCRIPTION
Fixing:
1. Adding support for converting classic SSL policy
2. Handling default CMP bindings
3. Handling builltin named expression and CR policies
4. Checking expression use in "set uiinternal EXPRESSION"