### PR TITLE
Logging line number in the warning, adding a comment for the invalid command in the new_<input_file>

### DIFF
--- a/nspepi/README.md
+++ b/nspepi/README.md
@@ -108,6 +108,10 @@ The following is an example when the configuration file does not contain any dep
 
 The `NSPEPI` tool helps in converting the deprecated commands or features to the Citrix recommended alternatives.
 
+**Latest version:**   1.2
+
+**NOTE:** It is recommended to always use the latest version for the conversion, you can check the version using `nspepi --version` command.
+
 ### Running the NSPEPI tool
 
 This tool needs to be run from the command line of the shell (you should type the `shell` command on the Citrix ADC CLI).

--- a/nspepi/nspepi2/check_classic_configs.py
+++ b/nspepi/nspepi2/check_classic_configs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2021-2023 Citrix Systems, Inc. All rights reserved.
+# Copyright 2021-2024 Citrix Systems, Inc. All rights reserved.
 # Use of this software is governed by the license terms, if any,
 # which accompany or are included with this software.
 
@@ -1222,7 +1222,7 @@ class Responder(CheckConfig):
         if commandParseTree.invalid:
             return [commandParseTree]
         action_type = commandParseTree.positional_value(1).value.lower()
-        if action_type is "noop":
+        if action_type == "noop":
             logging.warning("NOOP action type is deprecated"
                 " for command [{}]".format(str(commandParseTree).strip()))
         return []

--- a/nspepi/nspepi2/convert_cmp_cmd.py
+++ b/nspepi/nspepi2/convert_cmp_cmd.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2021-2023 Citrix Systems, Inc.  All rights reserved.
+# Copyright 2021-2024 Citrix Systems, Inc.  All rights reserved.
 # Use of this software is governed by the license terms, if any,
 # which accompany or are included with this software.
 
@@ -220,14 +220,14 @@ class CMP(cli_cmds.ConvertConfig):
                 bind_cmd_tree.keyword_value("state")[0].value.lower() == \
                 "disabled":
             logging.warning((
-                "Following bind command is commented out because"
+                "Line({}): Following bind command is commented out because"
                 " state is disabled. If state is disabled, then command"
                 " is not in use. Since state parameter is not supported"
                 " with the advanced configuration, so if we convert this"
                 " config then functionality will change. If command is"
                 " required please take a backup because comments will"
                 " not be saved in ns.conf after triggering 'save ns config': {}").
-                format(str(bind_cmd_tree).strip())
+                format(str(bind_cmd_tree.lineno), str(bind_cmd_tree).strip())
             )
             return ["#" + str(bind_cmd_tree)]
 

--- a/nspepi/nspepi2/convert_lb_cmd.py
+++ b/nspepi/nspepi2/convert_lb_cmd.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-# Copyright 2021-2023 Citrix Systems, Inc. All rights reserved.
+# Copyright 2021-2024 Citrix Systems, Inc. All rights reserved.
 # Use of this software is governed by the license terms, if any,
 # which accompany or are included with this software.
 
@@ -140,8 +140,9 @@ class LB(cli_cmds.ConvertConfig):
                 else:
                     # CONTENTS exists but not a simple expression.
                     # Throw error and don't convert.
-                    logging.error(("-rule in the following command has to be "
+                    logging.error(("Line({}): -rule in the following command has to be "
                                   "converted manually: {}").format(
+                                  str(add_lbvserver_parse_tree.lineno),
                                   str(add_lbvserver_parse_tree).strip()))
                 return [add_lbvserver_parse_tree]
 
@@ -176,7 +177,7 @@ class LB(cli_cmds.ConvertConfig):
             if len(removed_keywords) > 0:
                 removed_keywords.append("rule")
                 add_lbvserver_parse_tree.remove_keyword("rule")
-                logging.warning(("-rule classic expression results in boolean "
+                logging.warning(("Line({}): -rule classic expression results in boolean "
                                  "value. The equivalent advanced expression "
                                  "will result boolean value in string "
                                  "format. This will result in functionality "
@@ -184,7 +185,7 @@ class LB(cli_cmds.ConvertConfig):
                                  " or lbMethod. To aviod the functionality "
                                  "change, {} command is modified by removing "
                                  "the following keywords: {}.").format(
-                                 str(original_tree).strip(),
+                                 str(original_tree.lineno), str(original_tree).strip(),
                                  ", ".join(removed_keywords)))
         return [add_lbvserver_parse_tree]
 


### PR DESCRIPTION
1. Logging line number in the warning
2. Adding a comment for the invalid command in the new_<input_file> if it is not converted by the tool.